### PR TITLE
Fix nullpointer exception from journeymap overlay

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ minecraft {
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
+dependencies {
+    compile group: "info.journeymap", name: "journeymap-api", version: "1.12-1.4", changing: true
+}
+
 processResources
 {
     // this will ensure that this task is redone when the versions change.

--- a/src/main/java/com/gmail/nuclearcat1337/snitch_master/journeymap/SnitchImageFactory.java
+++ b/src/main/java/com/gmail/nuclearcat1337/snitch_master/journeymap/SnitchImageFactory.java
@@ -29,6 +29,8 @@ public class SnitchImageFactory {
 		if (renderList != null) {
 			com.gmail.nuclearcat1337.snitch_master.util.Color color = renderList.getListColor();
 			MapImage image = new MapImage(createSnitchField((float) color.getRed(), (float) color.getGreen(), (float) color.getBlue()));
+			image.setRotation(0);
+
 			ILocation loc = snitch.getLocation();
 			String displayID = loc.getX() + "," + loc.getY() + "," + loc.getZ() + "," + loc.getWorld();
 


### PR DESCRIPTION
This fixes a bug where a nullpointer exception was being thrown, by setting the rotation on map images.

Additionally, this adds the journeymap API to the build dependencies so the project can be built without manually adding journeymap to the classpath.